### PR TITLE
[BUGFIX] No localization when Sites are used

### DIFF
--- a/Classes/Service/CellService.php
+++ b/Classes/Service/CellService.php
@@ -10,6 +10,8 @@ use PhpOffice\PhpSpreadsheet\RichText\Run;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Style\Style;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use Hoogi91\Spreadsheets\Traits\SheetIndexTrait;
 
@@ -49,6 +51,16 @@ class CellService
         // evaluate typoscript configuration and locales
         $this->typoscriptConfig = $GLOBALS['TSFE']->config;
         $this->currentLocales = $this->typoscriptConfig['config']['locale_all'];
+
+        if ($this->currentLocales === null) {
+            // happens, when Sites are used in TYPO3 9+
+            $language = GeneralUtility::makeInstance(SiteFinder::class)
+                ->getSiteByPageId($GLOBALS['TSFE']->id)
+                ->getLanguageById(
+                    GeneralUtility::makeInstance(Context::class)->getPropertyFromAspect('language', 'id')
+                );
+            $this->currentLocales = $language->getLocale();
+        }
     }
 
     /**


### PR DESCRIPTION
When Sites are used, the locale can't be found in the TSFE-array thus localization fails
We found the problem in a 9.5 instance, but I assume is this an issue in TYPO3 10 as well