### PR TITLE
Fix BE-error when using legacy-tables

### DIFF
--- a/Classes/Domain/ValueObject/DsnValueObject.php
+++ b/Classes/Domain/ValueObject/DsnValueObject.php
@@ -130,6 +130,10 @@ class DsnValueObject
             $this->sheetIndex = (int)($sheetIndex ?: 0);
             $this->selection = $selection ?: null;
             $this->directionOfSelection = $directionOfSelection ?: null;
+        } else {
+            $this->sheetIndex = 0;
+            $this->selection = null;
+            $this->directionOfSelection = null;
         }
     }
 


### PR DESCRIPTION
Legacy spreadsheet-tables (created in TYPO3 V9 or below) seem to have null as its sheet-index when updating to TYPO3 V10, resulting in an exception in the backend

| Q             | A
| ------------- | ---
| Bug fix?      | yes
