### PR TITLE
Support PHP 8.3

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,6 +24,7 @@ jobs:
           - "lowest"
           - "highest"
         php-version:
+          - "8.3"
           - "8.2"
           - "8.1"
         operating-system:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "php": "~8.1.0 || ~8.2.0",
+    "php": "^8.1",
     "ext-json": "*",
     "ext-mbstring": "*",
     "phpoffice/phpspreadsheet": "^1.29 || ^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes/no
| Fixed tickets | #542

Allow PHP 8.3 so the extension can be used with TYPO3 websites running on PHP 8.3.